### PR TITLE
fix typo

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -733,7 +733,7 @@ With this extension, Clients can provide an Identifier for an upload - with whic
 can later retrieve the URL for the created resource.
 
 This allows Clients to resume an upload initiated through the [Creation With Upload](#creation-with-upload)
-or [Creation](#creation) extensions for which they did not reveive the response with
+or [Creation](#creation) extensions for which they did not receive the response with
 the newly created resource's URL (i.e. due to a broken connection).
 
 If the Server supports this extension, it MUST add `client-identifier` to the `Tus-Extension`


### PR DESCRIPTION
Furthermore, I think the `Upload-Client-Identifier` should just act as an optional id the client should use for the identifier in the upload url.
> To initiate an upload with Client Identifier, Clients MUST include an `Upload-Client-Identifier` header with the initial `POST` request (as specified in the Creation and Creation With Upload extensions).
>
> Clients can then send a `HEAD` request with the same `Upload-Client-Identifier` header to the same URL on the Server, which - upon success - MUST respond with the 200 OK or 204 No Content status, and the resource's URL in the response's Location header.

hmmm I see the problem ... when the request does not return you don't have the upload url and constructing it might not be possible. The endpoint for the upload might be a random server ...

The server might announce where it will make uploads available in a new header, eg `Upload-Location-Base`. That could be suffixed with the client id so clients can construct the Location themselves.

Maybe you can clarify somehow that the POST and HEAD request use a different endpoint than the upload location. hm ... needs thinking ... and a night of sleep.

